### PR TITLE
Use HTTP GET to download the db file and patch up multipart POST syntax

### DIFF
--- a/src/com/u17od/upm/transport/HTTPTransport.java
+++ b/src/com/u17od/upm/transport/HTTPTransport.java
@@ -85,14 +85,14 @@ public class HTTPTransport extends Transport {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             baos.write("--".getBytes());
             baos.write(BOUNDRY.getBytes());
-            baos.write("\n".getBytes());
+            baos.write("\r\n".getBytes());
             baos.write(contentDisposition.getBytes());
-            baos.write("\n".getBytes());
+            baos.write("\r\n".getBytes());
             baos.write(contentType.getBytes());
-            baos.write("\n".getBytes());
-            baos.write("\n".getBytes());
+            baos.write("\r\n".getBytes());
+            baos.write("\r\n".getBytes());
             baos.write(Util.getBytesFromFile(file));
-            baos.write("\n".getBytes());
+            baos.write("\r\n".getBytes());
             baos.write("--".getBytes());
             baos.write(BOUNDRY.getBytes());
             baos.write("--".getBytes());
@@ -166,7 +166,6 @@ public class HTTPTransport extends Transport {
                 conn.setRequestProperty ("Authorization", createAuthenticationString(username, password));
             }
 
-            conn.setDoOutput(true);
             conn.setDoInput(true);
             conn.setUseCaches(false);
             conn.setRequestMethod("GET");


### PR DESCRIPTION
The proposed changes fix adrian/upm-android#19 issue, enabling the use
of HTTP GET method instead of static HTTP POST to download the database
file.

The use of LF (instead of CRLF) confuses CGI.pm if CGI.pm is used to
process HTTP uploads. The proposed changes enable processing of HTTP
uploads by a custom CGI script in addition to, or as a replacement of,
the current PHP scripts.