### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/res/layout/add_edit_account_details.xml
+++ b/res/layout/add_edit_account_details.xml
@@ -42,6 +42,7 @@
                   android:layout_width="fill_parent" 
                   android:layout_height="wrap_content"
                   android:inputType="textVisiblePassword"
+                  android:importantForAccessibility="no"
                   android:layout_marginBottom="10dip"/>
 
         <TextView android:layout_width="wrap_content"

--- a/res/layout/change_master_password.xml
+++ b/res/layout/change_master_password.xml
@@ -26,6 +26,7 @@
                       android:layout_width="fill_parent" 
                       android:layout_height="wrap_content"
                       android:inputType="textPassword"
+                      android:importantForAccessibility="no"
                       android:layout_marginBottom="40dip"/>
 
             <TextView android:layout_width="wrap_content"
@@ -37,6 +38,7 @@
                       android:layout_width="fill_parent" 
                       android:layout_height="wrap_content"
                       android:inputType="textPassword"
+                      android:importantForAccessibility="no"
                       android:layout_marginBottom="10dip"/>
 
             <TextView android:layout_width="wrap_content"
@@ -48,6 +50,7 @@
                       android:layout_width="fill_parent" 
                       android:layout_height="wrap_content"
                       android:inputType="textPassword"
+                      android:importantForAccessibility="no"
                       android:layout_marginBottom="20dip"/>
 
         </LinearLayout>

--- a/res/layout/enter_master_password.xml
+++ b/res/layout/enter_master_password.xml
@@ -24,6 +24,7 @@
                     android:layout_width="fill_parent" 
                     android:layout_height="wrap_content"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:layout_marginBottom="20dip"/>
 
             <TextView android:layout_width="wrap_content"

--- a/res/layout/master_password_dialog.xml
+++ b/res/layout/master_password_dialog.xml
@@ -13,6 +13,7 @@
 	<EditText android:id="@+id/password" 
 	          android:layout_width="fill_parent" 
 	          android:layout_height="wrap_content"
+			  android:importantForAccessibility="no"
 	          android:inputType="textPassword"/>
 
     <Button android:id="@+id/master_password_ok_button"

--- a/res/layout/new_master_password_dialog.xml
+++ b/res/layout/new_master_password_dialog.xml
@@ -22,11 +22,13 @@
             <EditText android:id="@+id/password1" 
                       android:layout_width="fill_parent" 
                       android:layout_height="wrap_content"
+                      android:importantForAccessibility="no"
                       android:inputType="textPassword"/>
 
             <EditText android:id="@+id/password2" 
                       android:layout_width="fill_parent" 
                       android:layout_height="wrap_content"
+                      android:importantForAccessibility="no"
                       android:inputType="textPassword"/>
 
             <TextView android:layout_width="wrap_content"


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service, can capture all user inputs. In this case, password, should be ignored for the accessibility service, so such attacks can not be happened.